### PR TITLE
New APIs updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,10 +11,9 @@ License: GPL-3
 Depends:
     R (>= 4.0.0),
     EpiModel (>= 2.2.0),
-    network
-Imports:
-    ergm (>= 4.0),
     network (>= 1.17.0)
+Imports:
+    ergm (>= 4.0)
 Suggests:
     testthat (>= 3.0.0)
 RoxygenNote: 7.1.2

--- a/R/mod-simnet.R
+++ b/R/mod-simnet.R
@@ -2,11 +2,6 @@
 #' @rdname moduleset-ship
 #' @export
 resim_nets_covid_ship <- function(dat, at) {
-
-  # controls
-  set.control.stergm <- get_control(dat, "set.control.stergm")
-  set.control.ergm <- get_control(dat, "set.control.ergm")
-
   ## Edges correction
   dat <- edges_correct_covid(dat, at)
 
@@ -56,10 +51,12 @@ resim_nets_covid_ship <- function(dat, at) {
         object = nwparam[["formation"]],
         coef = nwparam[["coef.form"]],
         constraints = nwparam[["constraints"]],
-        control = set.control.ergm,
-        dynamic = FALSE,
-        nsim = 1,
-        output = "network"
+        control = set.control.tergm,
+        time.start = at - 1,
+        time.slices = 1,
+        time.offset = 1,
+        dynamic = TRUE,
+        output = "final"
       )
     }
 
@@ -130,10 +127,12 @@ resim_nets_covid_corporate <- function(dat, at) {
         object = nwparam[["formation"]],
         coef = nwparam[["coef.form"]],
         constraints = nwparam[["constraints"]],
-        control = set.control.ergm,
-        dynamic = FALSE,
-        nsim = 1,
-        output = "network"
+        control = set.control.tergm,
+        time.start = at - 1,
+        time.slices = 1,
+        time.offset = 1,
+        dynamic = TRUE,
+        output = "final"
       )
     }
 


### PR DESCRIPTION
- allow working with `trim_netest`
- deprecate `set.control.stergm`
- works with duration 1 dissolution `tergm`s